### PR TITLE
Reduce mobile header whitespace

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 {{- partial "head/head.html" . }}
 
 <body>
-  <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-4">
+  <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-9">
     {{- partial "header/header.html" . }}
     {{- block "main" . }}{{ end }}
     {{- partial "footer/footer.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 {{- partial "head/head.html" . }}
 
 <body>
-  <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-9">
+  <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-2">
     {{- partial "header/header.html" . }}
     {{- block "main" . }}{{ end }}
     {{- partial "footer/footer.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 {{- partial "head/head.html" . }}
 
 <body>
-  <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-2">
+  <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-4">
     {{- partial "header/header.html" . }}
     {{- block "main" . }}{{ end }}
     {{- partial "footer/footer.html" . }}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -1,6 +1,6 @@
 {{- $header := .Site.Params.header }}
 <header x-data="{sideNav: false, isSearch: false}" class="header relative">
-    <div class="nav w-full bg-primary border-b border-solid border-white/5 pt-6 lg:pt-0 bg-white/5">
+    <div class="nav w-full bg-primary border-b border-solid border-white/5 pt-2 lg:pt-0 bg-white/5">
         <div class="nav__container max-w-[640px] mx-auto px-6 md:px-0 relative">
             <div class="nav__wrapper flex flex-wrap items-center justify-between">
                 <div class="nav__brand logo w-[230px] md:w-[250px] lg:w-[45%] flex-none flex items-center">


### PR DESCRIPTION
## Summary
- reduce top padding in `baseof.html`
- reduce nav padding in header

## Testing
- `npm run build` *(fails: hugo not found)*