### PR TITLE
Open page-header links in new tab

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -8,7 +8,7 @@
         </div>
         <div class="inline-block">
             <a class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2"
-                href="{{ with .Site.Data.page_header.button_link }}{{ . }}{{ end }}">
+                href="{{ with .Site.Data.page_header.button_link }}{{ . }}{{ end }}" target="_blank" rel="noopener">
                 {{- with .Site.Data.page_header.button_text }}
                 <span class="leading-none">{{ . }}</span>
                 {{- end }}

--- a/layouts/partials/sections/page-header.html
+++ b/layouts/partials/sections/page-header.html
@@ -14,7 +14,7 @@
                 </div>
                 <div class="inline-block">
                     <a class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2"
-                        href="{{ .button_link }}">
+                        href="{{ .button_link }}" target="_blank" rel="noopener">
                         <span class="leading-none">{{ .button_text }}</span>
                         <span class="w-4 flex-none">
                             <svg class="w-full h-auto" viewBox="0 0 16 8" fill="currentcolor"


### PR DESCRIPTION
## Summary
- add `target="_blank"` and `rel="noopener"` to header button links so that the "Share Your Work" and "Watch the presentation" buttons open in a new tab

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: hugo not found)*