### PR TITLE
Add full-text search and improved UI

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -107,3 +107,15 @@ body {
 .hidden {
     display: none;
 }
+
+.search-result-item {
+    @apply border-b border-gray-200 pb-4;
+}
+
+.search-result-item:last-child {
+    @apply border-none;
+}
+
+.highlight {
+    @apply bg-yellow-200;
+}

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -7,19 +7,10 @@
       "id": {{ $index | jsonify }},
       "title": {{ $post.Title | jsonify }},
       "summary": {{ $post.Summary | plainify | safeHTML | truncate 180 | jsonify }},
-      "author": {{ index $post.Params.authors 0 | jsonify }},
-      "date": {{ $post.Date | time.Format ":date_long" | jsonify }},
-      "readingtime": {{ .ReadingTime | jsonify }},
-      "tags": {{ $post.Params.tags | jsonify }},
-    {{- if $post.Params.image }}
-    {{- if fileExists (add `assets/` (string $post.Params.image)) }}
-    {{- $image_src:= resources.Get $post.Params.image }}
-    {{- $image:= $image_src.Fill "450x290 webp q100" }}
-    {{- $image_list:= $image_src.Fill "450x378 webp q100" }}
-      "image": {{ $image.RelPermalink | jsonify }},
-      "cover": {{ $image_list.RelPermalink | jsonify }},
-    {{- end -}}
-    {{- end -}}
+      "content": {{ $post.Plain | jsonify }},
+      "author": {{ index $post.Params.authors 0 | default "" | jsonify }},
+      "date": {{ with $post.Date }}{{ . | time.Format ":date_long" | jsonify }}{{ else }}""{{ end }},
+      "tags": {{ $post.Params.tags | default slice | jsonify }},
       "url": {{ $post.Permalink | jsonify }}
     }
   {{- end -}}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,8 +1,13 @@
 {{ define "main" }}
-<main id="site-main" class="search-page">
+<main id="site-main" class="search-page py-12">
     <div class="container w-full max-w-screen-lg mx-auto md:px-5">
         <div class="px-5">
-            <div id="search-results" class="search-result"></div>
+            <div class="search-input-wrapper relative mb-6">
+                <input type="text" id="search-input" placeholder="Type to search..."
+                    class="search-input w-full text-lg text-black font-body placeholder:text-gray-400 outline-none border border-gray-300 rounded-md py-2 pl-4 pr-10" />
+                <span id="clear-input" class="clear-input hidden">×</span>
+            </div>
+            <div id="search-results" class="search-results space-y-6"></div>
         </div>
     </div>
 </main>

--- a/layouts/partials/header/search-box.html
+++ b/layouts/partials/header/search-box.html
@@ -1,10 +1,10 @@
 <div x-show="isSearch" x-transition.opacity x-cloak
-    class="fixed inset-0 bg-black/90 z-40 p-6 pt-40 overflow-auto">
-    <div class="bg-white w-full max-w-[640px] min-h-[500px] mx-auto h-auto relative rounded-[4px]">
-        <div class="pt-6 px-6 pb-10">
+    class="fixed inset-0 bg-black/70 z-40 p-6 pt-32 overflow-auto">
+    <div class="bg-white w-full max-w-3xl mx-auto h-auto relative rounded-lg shadow-lg">
+        <div class="pt-6 px-8 pb-10">
             <div class="flex justify-between items-center mb-5">
                 <div class="text-black font-heading font-light">
-                    <p>Search blog entries:</p>
+                    <p>Search blog posts:</p>
                 </div>
                 <div>
                     <button @click="isSearch = false"
@@ -15,10 +15,10 @@
             </div>
             <div class="search-input-wrapper relative">
                 <input type="text" id="search-input" placeholder="Type to search..."
-                    class="search-input w-full text-black font-body placeholder:text-gray-400 placeholder:font-heading outline-none border border-[#E5E5E5] rounded-[4px] py-1 pl-3" />
+                    class="search-input w-full text-lg text-black font-body placeholder:text-gray-400 placeholder:font-heading outline-none border border-gray-300 rounded-md py-2 pl-4 pr-10" />
                 <span id="clear-input" class="clear-input hidden">×</span>
             </div>
-            <div id="search-results" class="search-results max-w-[640px] mx-auto pt-6"></div>
+            <div id="search-results" class="search-results mt-6 space-y-6"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- rework `index.json` to index all pages and full content
- overhaul JavaScript search to use new index and generate snippets
- redesign the search modal and search page layouts
- style search result items and highlights
- limit search index to blog posts

## Testing
- `npm run build` *(fails: `hugo` not found)*