### PR TITLE
Implement menu fade-out on page navigation

### DIFF
--- a/assets/js/menu-fade.js
+++ b/assets/js/menu-fade.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const headerEl = document.querySelector('header[x-data]');
+  if (!headerEl) return;
+  const menuLinks = headerEl.querySelectorAll('.nav__menu a[href]');
+  menuLinks.forEach(link => {
+    link.addEventListener('click', (e) => {
+      if (window.innerWidth >= 1024) return; // only for mobile/tablet
+      const alpine = headerEl.__x;
+      if (!alpine || !alpine.$data.sideNav) return;
+      if (link.target === '_blank') return;
+      e.preventDefault();
+      alpine.$data.sideNav = false;
+      setTimeout(() => {
+        window.location.href = link.href;
+      }, 300);
+    });
+  });
+});

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -4,8 +4,9 @@
 {{- $persist := resources.Get "js/vendor/persist/dist/cdn.min.js" }}
 {{- $minisearch := resources.Get "js/vendor/minisearch/dist/umd/index.js" }}
 {{- $search := resources.Get "js/search.js" }}
+{{- $menufade := resources.Get "js/menu-fade.js" }}
 
 <!-- Combine JS -->
-{{- $js := slice $persist $collapse $minisearch $search $alpine | resources.Concat "js/main.js" }}
+{{- $js := slice $persist $collapse $minisearch $search $menufade $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
 <script defer src="{{ $js_min.RelPermalink }}"></script>


### PR DESCRIPTION
## Summary
- add menu fade logic for mobile/tablet
- include new script in site JS bundle

## Testing
- `npm run build` *(fails: hugo not found)*