### PR TITLE
Implement menu fade-out on page navigation

### DIFF
--- a/assets/js/menu-fade.js
+++ b/assets/js/menu-fade.js
@@ -1,0 +1,18 @@
+function headerComponent() {
+  return {
+    sideNav: false,
+    isSearch: false,
+    handleMenuLinkClick(event) {
+      const link = event.target.closest('a[href]');
+      if (!link) return;
+      if (window.innerWidth >= 1024) return;
+      if (link.target === '_blank') return;
+      event.preventDefault();
+      this.sideNav = false;
+      setTimeout(() => {
+        window.location.href = link.href;
+      }, 300);
+    }
+  };
+}
+

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -4,8 +4,9 @@
 {{- $persist := resources.Get "js/vendor/persist/dist/cdn.min.js" }}
 {{- $minisearch := resources.Get "js/vendor/minisearch/dist/umd/index.js" }}
 {{- $search := resources.Get "js/search.js" }}
+{{- $menufade := resources.Get "js/menu-fade.js" }}
 
 <!-- Combine JS -->
-{{- $js := slice $persist $collapse $minisearch $search $alpine | resources.Concat "js/main.js" }}
+{{- $js := slice $persist $collapse $minisearch $search $menufade $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
 <script defer src="{{ $js_min.RelPermalink }}"></script>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -1,5 +1,5 @@
 {{- $header := .Site.Params.header }}
-<header x-data="{sideNav: false, isSearch: false}" class="header relative">
+<header x-data="headerComponent()" class="header relative">
     <div class="nav w-full bg-primary border-b border-solid border-white/5 pt-2 lg:pt-0 bg-white/5">
         <div class="nav__container max-w-[640px] mx-auto px-6 md:px-0 relative">
             <div class="nav__wrapper flex flex-wrap items-center justify-between">
@@ -16,7 +16,8 @@
                 </div>
                 <div x-cloak
                     class="nav__menu flex-1 fixed lg:static w-full h-screen lg:h-auto left-0 top-0 transition-all duration-300 ease-[ease] z-20"
-                    :class="sideNav ? 'visible opacity-100' : 'invisible lg:visible opacity-0 lg:opacity-100'">
+                    :class="sideNav ? 'visible opacity-100' : 'invisible lg:visible opacity-0 lg:opacity-100'"
+                    @click="handleMenuLinkClick">
                     <nav x-data="{ selectedMenu: null, dropdownMenu: false }"
                         class="navbar w-full h-full lg:h-auto bg-[#003b70] lg:bg-transparent relative pt-[80px] lg:pt-0">
                         <ul


### PR DESCRIPTION
## Summary
- improve mobile menu fade logic via Alpine component
- attach click handler to close menu before navigating

## Testing
- `npm run build` *(fails: hugo not found)*