### PR TITLE
Add fade transitions to page navigation

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,13 @@
+body.page-transition {
+  opacity: 0;
+}
+
+body.page-transition.page-loaded {
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+body.page-transition.fade-out {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}

--- a/assets/js/page-transition.js
+++ b/assets/js/page-transition.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add('page-loaded');
+
+  document.querySelectorAll('a').forEach(link => {
+    const href = link.getAttribute('href');
+    if (!href || href.startsWith('#') || href.startsWith('mailto:')) return;
+    const url = new URL(link.href, window.location.origin);
+    if (url.origin !== window.location.origin) return;
+
+    link.addEventListener('click', e => {
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+      e.preventDefault();
+      document.body.classList.add('fade-out');
+      setTimeout(() => {
+        window.location.href = link.href;
+      }, 300);
+    });
+  });
+});

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode | default `en-US` }}">
 {{- partial "head/head.html" . }}
 
-<body>
+<body class="page-transition">
   <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-9">
     {{- partial "header/header.html" . }}
     {{- block "main" . }}{{ end }}

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -4,8 +4,9 @@
 {{- $persist := resources.Get "js/vendor/persist/dist/cdn.min.js" }}
 {{- $minisearch := resources.Get "js/vendor/minisearch/dist/umd/index.js" }}
 {{- $search := resources.Get "js/search.js" }}
+{{- $transition := resources.Get "js/page-transition.js" }}
 
 <!-- Combine JS -->
-{{- $js := slice $persist $collapse $minisearch $search $alpine | resources.Concat "js/main.js" }}
+{{- $js := slice $persist $collapse $minisearch $search $transition $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
 <script defer src="{{ $js_min.RelPermalink }}"></script>


### PR DESCRIPTION
## Summary
- add page transition CSS and JS assets
- include transition script in bundled JS
- mark `<body>` for transitions

## Testing
- `npm run build` *(fails: `hugo` not found)*