### PR TITLE
Improve footer back-to-top button

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode | default `en-US` }}">
 {{- partial "head/head.html" . }}
 
-<body>
+<body id="page-top">
   <div class="overflow-hidden lg:border-[14px] lg:border-[#0074C8] pt-9">
     {{- partial "header/header.html" . }}
     {{- block "main" . }}{{ end }}
@@ -15,8 +15,12 @@
         const targetId = this.getAttribute('href').substring(2);
         const targetElement = document.getElementById(targetId);
         if (targetElement) {
+          let offset = targetElement.offsetTop - 80;
+          if (targetId === 'page-top') {
+            offset = 0;
+          }
           window.scrollTo({
-            top: targetElement.offsetTop - 80,
+            top: offset,
             behavior: 'smooth',
           });
         }

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -7,7 +7,7 @@
                 {{- end }}
             </div>
             <div>
-                <a class="size-9 flex items-center justify-center border border-black rounded-[4px]" href="#main">
+                <a class="size-9 flex items-center justify-center border border-black rounded-[4px]" href="/#page-top">
                     <svg width="8" height="16" viewBox="0 0 8 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M4.35355 0.646445C4.15829 0.451183 3.84171 0.451183 3.64645 0.646445L0.464466 3.82843C0.269203 4.02369 0.269203 4.34027 0.464466 4.53553C0.659728 4.7308 0.97631 4.7308 1.17157 4.53553L4 1.70711L6.82843 4.53553C7.02369 4.73079 7.34027 4.73079 7.53553 4.53553C7.7308 4.34027 7.7308 4.02369 7.53553 3.82843L4.35355 0.646445ZM4.5 16L4.5 0.999999L3.5 0.999999L3.5 16L4.5 16Z" fill="black"/>
                     </svg>                        


### PR DESCRIPTION
## Summary
- ensure body has `id="page-top"`
- adjust smooth-scroll script to handle `page-top`
- update footer button link to `/#page-top`

## Testing
- `npm run build` *(fails: hugo not found)*