### PR TITLE
Fix vertical centering of hamburger menu

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -18,7 +18,7 @@
                     class="nav__menu flex-1 fixed lg:static w-full h-screen lg:h-auto left-0 top-0 transition-all duration-300 ease-[ease] z-20"
                     :class="sideNav ? 'visible opacity-100' : 'invisible lg:visible opacity-0 lg:opacity-100'">
                     <nav x-data="{ selectedMenu: null, dropdownMenu: false }"
-                        class="navbar w-full h-full lg:h-auto bg-[#003b70] lg:bg-transparent relative pt-[80px] lg:pt-0">
+                        class="navbar w-full h-full lg:h-auto bg-[#003b70] lg:bg-transparent relative flex flex-col items-center justify-center lg:block pt-0 lg:pt-0">
                         <ul
                             class="navbar__menu menu lg:flex lg:items-center lg:justify-end list-none pl-0 px-2 lg:px-0 pb-2 lg:pb-0 mb-0">
                             {{- $currentPage := . }}


### PR DESCRIPTION
## Summary
- vertically center the mobile navigation menu

## Testing
- `npm run build` *(fails: `hugo: not found`)*