### PR TITLE
Fix regex special character escaping in search query

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -104,7 +104,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
     function highlightQuery(text, query) {
         if (!query) return text; // Prevent errors if query is empty
-        const regex = new RegExp(`(${query})`, "gi");
+
+        // Escape special characters in the query to create a safe RegExp
+        const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+        const regex = new RegExp(`(${escapedQuery})`, "gi");
         return text.replace(regex, '<span class="highlight">$1</span>');
     }
 


### PR DESCRIPTION
## Summary
- escape special characters in `highlightQuery` to avoid regex errors

## Testing
- `npm run build` *(fails: hugo not found)*