### PR TITLE
Fix search width

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <main id="site-main" class="search-page py-12">
-    <div class="container w-full max-w-screen-lg mx-auto md:px-5">
+    <div class="container w-full max-w-[710px] mx-auto md:px-5">
         <div class="px-5">
             <div class="search-input-wrapper relative mb-6">
                 <input type="text" id="search-input" placeholder="Type to search..."

--- a/layouts/partials/header/search-box.html
+++ b/layouts/partials/header/search-box.html
@@ -1,6 +1,6 @@
 <div x-show="isSearch" x-transition.opacity x-cloak
     class="fixed inset-0 bg-black/70 z-40 p-6 pt-32 overflow-auto">
-    <div class="bg-white w-full max-w-3xl mx-auto h-auto relative rounded-lg shadow-lg">
+    <div class="bg-white w-full max-w-[640px] mx-auto h-auto relative rounded-lg shadow-lg">
         <div class="pt-6 px-8 pb-10">
             <div class="flex justify-between items-center mb-5">
                 <div class="text-black font-heading font-light">


### PR DESCRIPTION
## Summary
- keep search overlay width consistent with other sections
- use same width on search page

## Testing
- `npm run build` *(fails: `hugo: command not found`)*