### PR TITLE
Add link to USD in header

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -10,8 +10,10 @@
                         </a>
                     </div>
                     {{- if .Site.Data.header.title }}
-                    <a class="text-[#003B70] text-sm md:text-base lg:text-base font-heading font-normal leading-tight"
-                        href="{{ .Site.BaseURL }}">{{ .Site.Data.header.title | safeHTML }}</a>
+                    <span class="text-[#003B70] text-sm md:text-base lg:text-base font-heading font-normal leading-tight">
+                        <a href="{{ .Site.BaseURL }}">The Science, Technology, and Society Initiative at the </a>
+                        <a href="https://sandiego.edu" target="_blank" rel="noopener">University of San Diego</a>
+                    </span>
                     {{- end }}
                 </div>
                 <div x-cloak


### PR DESCRIPTION
## Summary
- tweak header so "University of San Diego" links to `https://sandiego.edu`

## Testing
- `npm run build` *(fails: `hugo` not found)*