### PR TITLE
Add link to USD in header

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -10,8 +10,11 @@
                         </a>
                     </div>
                     {{- if .Site.Data.header.title }}
-                    <a class="text-[#003B70] text-sm md:text-base lg:text-base font-heading font-normal leading-tight"
-                        href="{{ .Site.BaseURL }}">{{ .Site.Data.header.title | safeHTML }}</a>
+                    {{ $title := .Site.Data.header.title }}
+                    {{ $prefix := replace $title "University of San Diego" "" }}
+                    <span class="text-[#003B70] text-sm md:text-base lg:text-base font-heading font-normal leading-tight">
+                        <a class="text-[#003B70]" href="{{ .Site.BaseURL }}">{{ $prefix }}</a><a class="text-[#003B70]" href="https://sandiego.edu" target="_blank" rel="noopener">University of San Diego</a>
+                    </span>
                     {{- end }}
                 </div>
                 <div x-cloak


### PR DESCRIPTION
## Summary
- tweak header so "University of San Diego" links externally in a new tab

## Testing
- `npm run build` *(fails: `hugo` not found)*