### PR TITLE
Fix FAQ collapse padding

### DIFF
--- a/layouts/partials/sections/about-aq.html
+++ b/layouts/partials/sections/about-aq.html
@@ -27,11 +27,13 @@
                             </svg>                                
                         </div>
                     </div>
-                    <div x-show="openIndex === {{ $index }}" x-collapse.duration.300ms x-transition.opacity.duration.300ms.transform-gpu class="pt-5 overflow-hidden">
-                        {{- with .description }}
-                        {{- $include_dict := dict "content" . }}
-                        {{ partial "markdownify.html" $include_dict }}
-                        {{- end }}
+                    <div x-show="openIndex === {{ $index }}" x-collapse.duration.300ms x-transition.opacity.duration.300ms.transform-gpu class="overflow-hidden">
+                        <div class="pt-5">
+                            {{- with .description }}
+                            {{- $include_dict := dict "content" . }}
+                            {{ partial "markdownify.html" $include_dict }}
+                            {{- end }}
+                        </div>
                     </div>
                 </div>
                 {{- end }}


### PR DESCRIPTION
## Summary
- remove padding from collapse element to prevent stutter when closing FAQ sections

## Testing
- `npm run build` *(fails: hugo not found)*
- `npm test` *(fails: missing script)*