### PR TITLE
Fix header spacing on tablet

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,7 +1,7 @@
 <div class="px-6 md:px-0">
     <div
         class="max-w-[640px] mx-auto py-6 border-y border-y-[#E5E5E5] md:flex md:justify-between md:items-center mb-12">
-        <div class="md:w-[70%] md:flex-none mb-6 lg:mb-0">
+        <div class="md:w-[70%] md:flex-none mb-6 md:mb-0">
             {{- with .Site.Data.page_header.title }}
             <h2 class="text-black text-2xl font-heading font-normal leading-tight mb-0">{{ . | safeHTML }}</h2>
             {{- end }}

--- a/layouts/partials/sections/page-header.html
+++ b/layouts/partials/sections/page-header.html
@@ -7,7 +7,7 @@
         <div class="px-6 md:px-0">
             <div
                 class="max-w-[640px] mx-auto py-6 border-y border-y-[#E5E5E5] md:flex md:justify-between md:items-center mb-12">
-                <div class="md:w-[70%] md:flex-none mb-6 lg:mb-0">
+                <div class="md:w-[70%] md:flex-none mb-6 md:mb-0">
                     {{- with .title }}
                     <h2 class="text-black text-2xl font-heading font-normal leading-tight mb-0">{{ . | safeHTML }}</h2>
                     {{- end }}


### PR DESCRIPTION
## Summary
- fix header layout spacing for tablet screens

## Testing
- `npm run build` *(fails: hugo not found)*