### PR TITLE
Add STS-I text on mobile menu

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -82,6 +82,9 @@
                             {{- end }}
                         </ul>
                     </nav>
+                    <p class="absolute bottom-6 left-1/2 -translate-x-1/2 text-white opacity-50 italic font-heading lg:hidden">
+                        STS-I at USD
+                    </p>
                 </div>
                 <div class="flex items-center justify-end">
                     <div class="w-6 flex-none flex items-center justify-center ml-2">


### PR DESCRIPTION
## Summary
- show a white, italic "STS-I at USD" label near the bottom of the mobile menu

## Testing
- `npm run build` *(fails: hugo not found)*