### PR TITLE
Add separator above blog posts

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,9 @@
 {{- define "main" }}
 <div id="main" class="page-list pt-10">
     <div class="container w-full max-w-[710px] mx-auto">
+        {{- if eq .Section "blog" }}
+        <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        {{- end }}
         <div>
             {{- $paginator := .Paginate .Data.Pages }}
             {{- range $paginator.Pages }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,6 +2,9 @@
 <div id="main" class="home pt-10">
     <div class="container w-full max-w-[710px] mx-auto">
         {{/*  {{ partial "page-header.html" . }}  */}}
+        {{- if eq .Section "blog" }}
+        <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        {{- end }}
         <div>
             {{- if eq .Section "blog" }}
             <header class="max-w-[640px] mx-auto mb-10 px-6 md:px-0">


### PR DESCRIPTION
## Summary
- add a thin separator bar before blog list and single blog posts

## Testing
- `npm run build` *(fails: hugo not found)*