### PR TITLE
Fix mobile blog separator width

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,9 @@
 <div id="main" class="page-list pt-10">
     <div class="container w-full max-w-[710px] mx-auto">
         {{- if eq .Section "blog" }}
-        <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        <div class="px-6 lg:px-0">
+            <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        </div>
         {{- end }}
         <div>
             {{- $paginator := .Paginate .Data.Pages }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,9 @@
     <div class="container w-full max-w-[710px] mx-auto">
         {{/*  {{ partial "page-header.html" . }}  */}}
         {{- if eq .Section "blog" }}
-        <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        <div class="px-6 lg:px-0">
+            <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        </div>
         {{- end }}
         <div>
             {{- if eq .Section "blog" }}


### PR DESCRIPTION
## Summary
- match top blog separator bar width to bottom separator bar on mobile

## Testing
- `npm run build` *(fails: hugo not found)*