### PR TITLE
Add pdf embedding shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ The Science, Technology, & Society Initiative (STS-I) at USD aims to establish a
 
 1. Install dependencies with `npm install` or `yarn install`.
 2. Start the site with `hugo server` or `npm run dev`.
+
+## Embedding PDFs in Posts
+
+Use the `pdf` shortcode to display PDF files within blog posts.
+
+```
+{{</* pdf src="/path/to/file.pdf" title="Descriptive title" height="600px" */>}}
+```
+
+`src` is the path to the PDF (relative to the site root), `title` is optional, and `height` sets the viewer height.

--- a/layouts/shortcodes/pdf.html
+++ b/layouts/shortcodes/pdf.html
@@ -1,0 +1,6 @@
+{{ $src := .Get "src" }}
+{{ $title := .Get "title" | default "PDF viewer" }}
+{{ $height := .Get "height" | default "600px" }}
+<div class="my-6">
+  <iframe src="{{ $src }}" title="{{ $title }}" class="w-full border border-gray-200 rounded" style="height: {{ $height }};" allow="autoplay"></iframe>
+</div>


### PR DESCRIPTION
## Summary
- provide a `pdf` shortcode for embedding PDF files
- document how to use the new shortcode in README

## Testing
- `npm run build` *(fails: hugo not found)*