### PR TITLE
Add responsive height for meeting recap PDF

### DIFF
--- a/content/blog/inaugural_meeting_recap/index.md
+++ b/content/blog/inaugural_meeting_recap/index.md
@@ -17,3 +17,5 @@ The evening's featured speaker, Lochlann Jain, PhD-Professor of Anthropology at 
 STS-I was proud to co-host the program with USD's Humanities Center, the Department of Philosophy, and the Biomedical Ethics Program. Their support reflects a shared commitment to cultivating scientifically literate, socially responsible leaders. Attendees also earned COMPASS, CONNECT, and PASSPORT co-curricular credit-demonstrating alignment between the initiative's objectives and the University of San Diego's socially-responsible priorities.
 
 Stay tuned-more speaker events, workshops, and announcements are on the horizon as STS-I continues to collaborate with students, staff, and faculty across the University of San Diego. Connect with us to join the movement!
+
+{{< pdf src="STS_April_29_Poster.pdf" title="STS-I April 29 Poster" ratio="1.3" >}}

--- a/layouts/shortcodes/pdf.html
+++ b/layouts/shortcodes/pdf.html
@@ -1,6 +1,26 @@
 {{ $src := .Get "src" }}
 {{ $title := .Get "title" | default "PDF viewer" }}
 {{ $height := .Get "height" | default "600px" }}
+{{ $ratio := .Get "ratio" }}
+{{ $id := printf "pdf-%d" (now.UnixNano) }}
 <div class="my-6">
-  <iframe src="{{ $src }}" title="{{ $title }}" class="w-full border border-gray-200 rounded" style="height: {{ $height }};" allow="autoplay"></iframe>
+  <iframe id="{{ $id }}" src="{{ $src }}#view=FitH" title="{{ $title }}" class="w-full border border-gray-200 rounded" style="height: {{ $height }};" allow="autoplay"></iframe>
 </div>
+{{ if $ratio }}
+<script>
+(function(){
+  var id = {{ printf "%q" $id }};
+  var ratio = parseFloat({{ printf "%q" $ratio }});
+  function adjust(){
+    var iframe = document.getElementById(id);
+    if(!iframe) return;
+    var width = iframe.offsetWidth;
+    if(width > 0 && !isNaN(ratio)){
+      iframe.style.height = (width * ratio) + 'px';
+    }
+  }
+  window.addEventListener('load', adjust);
+  window.addEventListener('resize', adjust);
+})();
+</script>
+{{ end }}


### PR DESCRIPTION
## Summary
- tweak pdf shortcode to support dynamic sizing via a `ratio` parameter
- embed the event poster PDF using the new option

## Testing
- `git status --short`
