### PR TITLE
Fix mobile nav tagline placement

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -82,7 +82,7 @@
                             {{- end }}
                         </ul>
                     </nav>
-                    <p class="absolute bottom-6 left-1/2 -translate-x-1/2 text-white opacity-50 italic font-heading lg:hidden">
+                    <p class="absolute bottom-20 left-1/2 -translate-x-1/2 text-white opacity-50 italic font-heading lg:hidden">
                         STS-I at USD
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- tweak the mobile navigation tagline position

## Testing
- `npm run build` *(fails: hugo not installed)*