### PR TITLE
Redesign tags

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,4 +1,7 @@
 {{- define "main" }}
+    {{- if and (eq .Kind "taxonomy") (eq .Data.Plural "tags") }}
+        <meta http-equiv="refresh" content="0; url=/" />
+    {{- else }}
 <div id="main" class="page-taxonomy pt-[26px]">
     <div class="container w-full max-w-[710px] mx-auto">
         {{/*  {{ partial "page-header.html" . }}  */}}
@@ -50,4 +53,5 @@
         </nav>
     </div>
 </div>
+    {{- end }}
 {{- end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,4 +1,51 @@
 {{- define "main" }}
+{{- if eq .Data.Plural "tags" }}
+<div id="main" class="term py-10">
+    <div class="container w-full max-w-[710px] mx-auto">
+        <header class="max-w-[640px] mx-auto text-center mb-8">
+            <h1 class="text-[#0E4678] text-4xl font-heading font-normal mb-4">Posts tagged <span class="font-semibold">#{{ .Title }}</span></h1>
+            <a class="text-white text-sm font-body bg-black py-1 px-2 rounded-[4px]" href="/blog">View All Posts</a>
+        </header>
+        {{- $paginator := .Paginate .Data.Pages }}
+        <div class="space-y-10">
+            {{- range $paginator.Pages }}
+            {{ partial "post-card.html" . }}
+            {{- end }}
+        </div>
+        <nav class="max-w-[640px] mx-auto py-6 border-b border-b-[#E5E5E5] relative px-6 md:px-0">
+            <div class="absolute top-0 left-0 w-full h-full flex justify-center items-center">
+                <span class="text-black text-sm font-body mx-auto">
+                    Page {{ $paginator.PageNumber }} of {{ $paginator.TotalPages }}
+                </span>
+            </div>
+            <div class="flex justify-between items-center relative z-10">
+                {{- if $paginator.HasPrev }}
+                <a href="{{ $paginator.Prev.URL }}"
+                    class="text-primary text-sm font-body hover:underline flex items-center space-x-2">
+                    <span class="w-4 flex-none">
+                        <svg class="w-full h-auto rotate-180" viewBox="0 0 16 8" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M15.3536 4.35355C15.5488 4.15829 15.5488 3.84171 15.3536 3.64645L12.1716 0.464466C11.9763 0.269204 11.6597 0.269204 11.4645 0.464466C11.2692 0.659728 11.2692 0.976311 11.4645 1.17157L14.2929 4L11.4645 6.82843C11.2692 7.02369 11.2692 7.34027 11.4645 7.53553C11.6597 7.7308 11.9763 7.7308 12.1716 7.53553L15.3536 4.35355ZM0 4.5H15V3.5H0V4.5Z" fill="#0074C8"></path>
+                        </svg>
+                    </span>
+                    <span>New posts</span>
+                </a>
+                {{- end }}
+                {{- if $paginator.HasNext }}
+                <a href="{{ $paginator.Next.URL }}"
+                    class="text-primary text-sm font-body hover:underline ml-auto flex items-center space-x-2">
+                    <span>Older posts</span>
+                    <span class="w-4 flex-none">
+                        <svg class="w-full h-auto" viewBox="0 0 16 8" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M15.3536 4.35355C15.5488 4.15829 15.5488 3.84171 15.3536 3.64645L12.1716 0.464466C11.9763 0.269204 11.6597 0.269204 11.4645 0.464466C11.2692 0.659728 11.2692 0.976311 11.4645 1.17157L14.2929 4L11.4645 6.82843C11.2692 7.02369 11.2692 7.34027 11.4645 7.53553C11.6597 7.7308 11.9763 7.7308 12.1716 7.53553L15.3536 4.35355ZM0 4.5H15V3.5H0V4.5Z" fill="#0074C8"></path>
+                        </svg>
+                    </span>
+                </a>
+                {{- end }}
+            </div>
+        </nav>
+    </div>
+</div>
+{{- else }}
 <div id="main" class="term pt-10">
     <div class="container w-full max-w-[710px] mx-auto">
         <header class="max-w-[640px] mx-auto text-center">
@@ -19,4 +66,5 @@
         {{ partial "pagination.html" . }}
     </div>
 </div>
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
- add redirect on empty tags taxonomy page
- update term page design for tags

## Testing
- `npm run build` *(fails: hugo not found)*