### PR TITLE
Add separators on tag pages

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -2,10 +2,16 @@
 {{- if eq .Data.Plural "tags" }}
 <div id="main" class="term py-10">
     <div class="container w-full max-w-[710px] mx-auto">
+        <div class="px-6 lg:px-0">
+            <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        </div>
         <header class="max-w-[640px] mx-auto text-center mb-8">
             <h1 class="text-[#0E4678] text-4xl font-heading font-normal mb-4">Posts tagged <span class="font-semibold">#{{ .Title }}</span></h1>
             <a class="text-white text-sm font-body bg-black py-1 px-2 rounded-[4px]" href="/blog">View All Posts</a>
         </header>
+        <div class="px-6 lg:px-0">
+            <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        </div>
         {{- $paginator := .Paginate .Data.Pages }}
         <div class="space-y-10">
             {{- range $paginator.Pages }}


### PR DESCRIPTION
## Summary
- add horizontal separators to tag pages so they're consistent with blog list pages

## Testing
- `npm run build` *(fails: `hugo` not found)*