### PR TITLE
Ensure PDF shows full page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Use the `pdf` shortcode to display PDF files within blog posts.
 {{</* pdf src="/path/to/file.pdf" title="Descriptive title" height="600px" */>}}
 ```
 
-`src` is the path to the PDF (relative to the site root), `title` is optional, and `height` sets the viewer height.
+`src` is the path to the PDF (relative to the site root), `title` is optional, and `height` sets the viewer height. Embedded PDFs are loaded with the `Fit` view so the entire document page is always visible regardless of screen size.

--- a/layouts/shortcodes/pdf.html
+++ b/layouts/shortcodes/pdf.html
@@ -4,7 +4,7 @@
 {{ $ratio := .Get "ratio" }}
 {{ $id := printf "pdf-%d" (now.UnixNano) }}
 <div class="my-6">
-  <iframe id="{{ $id }}" src="{{ $src }}#view=FitH" title="{{ $title }}" class="w-full border border-gray-200 rounded" style="height: {{ $height }};" allow="autoplay"></iframe>
+  <iframe id="{{ $id }}" src="{{ $src }}#view=Fit" title="{{ $title }}" class="w-full border border-gray-200 rounded" style="height: {{ $height }};" allow="autoplay"></iframe>
 </div>
 {{ if $ratio }}
 <script>


### PR DESCRIPTION
## Summary
- show full PDF page by default with `view=Fit`
- document new behaviour for embedded PDFs

## Testing
- `npm run build` *(fails: `hugo` not found)*