### PR TITLE
Fix STS-I label position in mobile menu

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -82,7 +82,7 @@
                             {{- end }}
                         </ul>
                     </nav>
-                    <p class="absolute bottom-24 left-1/2 -translate-x-1/2 text-white opacity-50 italic font-heading lg:hidden">
+                    <p class="absolute bottom-32 left-1/2 -translate-x-1/2 text-white opacity-50 italic font-heading lg:hidden">
                         STS-I at USD
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- tweak position of brand text in mobile nav menu

## Testing
- `npm run build` *(fails: hugo not found)*