### PR TITLE
Fix tag page navigation

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -7,7 +7,7 @@
         </div>
         <header class="max-w-[640px] mx-auto text-center mb-8">
             <h1 class="text-[#0E4678] text-4xl font-heading font-normal mb-4">Posts tagged <span class="font-semibold">#{{ .Title }}</span></h1>
-            <a class="text-white text-sm font-body bg-black py-1 px-2 rounded-[4px]" href="/blog">View All Posts</a>
+            <a class="text-white text-sm font-body bg-black py-1 px-2 rounded-[4px]" href="/">View All Posts</a>
         </header>
         <div class="px-6 lg:px-0">
             <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>


### PR DESCRIPTION
## Summary
- update "View All Posts" link on tag pages to go to `/`

## Testing
- `grep -n "View All Posts" -n layouts/_default/term.html`