### PR TITLE
Fix tag page header style

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -5,8 +5,8 @@
         <div class="px-6 lg:px-0">
             <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
         </div>
-        <header class="max-w-[640px] mx-auto text-center mb-8">
-            <h1 class="text-[#0E4678] text-4xl font-heading font-normal mb-4">Posts tagged <span class="font-semibold">#{{ .Title }}</span></h1>
+        <header class="max-w-[640px] mx-auto flex items-center justify-between mb-8 px-6 lg:px-0">
+            <h1 class="text-black text-4xl font-heading font-normal mb-0">Posts tagged <span class="font-semibold">#{{ .Title }}</span></h1>
             <a class="inline-flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2 transition-colors duration-300 ease-[ease] hover:bg-[#0074c8] hover:text-white hover:border-[#0074c8]" href="/">
                 <span class="leading-none">View All Posts</span>
                 <span class="w-4 flex-none">


### PR DESCRIPTION
## Summary
- update tag page header to be black and inline with the button

## Testing
- `npm run build` *(fails: hugo not found)*