### PR TITLE
Add author profile layout

### DIFF
--- a/content/authors/erika-atienza/_index.md
+++ b/content/authors/erika-atienza/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Erika Atienza"
 description: "Erika believes medicine cannot be studied through practice alone. As an aspiring physician-social scientist, she aims to address pain and suffering as part of a larger quest to reunite the sciences and humanities."
-cover: profile.png
+cover: profile.jpeg
 ---
 

--- a/content/authors/leo-ambrogelly/_index.md
+++ b/content/authors/leo-ambrogelly/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Leo Ambrogelly"
 description: "Leo Ambrogelly is a contributor to the STS-I initiative."
-cover: profile.png
+cover: profile.jpeg
 ---
 

--- a/layouts/authors/term.html
+++ b/layouts/authors/term.html
@@ -1,0 +1,27 @@
+{{- define "main" }}
+<div id="main" class="author-term py-10">
+    <div class="container w-full max-w-[710px] mx-auto">
+        <header class="max-w-[640px] mx-auto text-center pb-10 border-b border-b-[#E5E5E5]">
+            {{- with .Resources.GetMatch .Params.cover }}
+                {{- with .Resize "160x" }}
+                    <img class="mx-auto rounded-full mb-6" src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="{{ $.Title }}" />
+                {{- end }}
+            {{- end }}
+            <h1 class="text-[#0E4678] text-4xl font-heading font-normal mb-4">{{ .Title }}</h1>
+            {{- with .Params.description }}
+            <p class="text-black text-lg font-body">{{ . }}</p>
+            {{- end }}
+        </header>
+        <div class="px-6 lg:px-0">
+            <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+        </div>
+        {{- $paginator := .Paginate .Data.Pages }}
+        <div class="space-y-10">
+            {{- range $paginator.Pages }}
+            {{ partial "post-card.html" . }}
+            {{- end }}
+        </div>
+        {{ partial "pagination.html" . }}
+    </div>
+</div>
+{{- end }}


### PR DESCRIPTION
## Summary
- add an `authors/term.html` template
- reference `profile.jpeg` in author metadata

## Testing
- `npm run build` *(fails: hugo not found)*