### PR TITLE
Fix search not working under subpath

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -10,7 +10,8 @@ document.addEventListener("DOMContentLoaded", () => {
     let miniSearch;
 
     // Fetch JSON and initialize MiniSearch
-    fetch("/index.json")
+    const basePath = window.__BASE_URL__ || "/";
+    fetch(basePath + "index.json")
         .then((response) => response.json())
         .then((data) => {
             const posts = data.posts;

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -8,4 +8,5 @@
 <!-- Combine JS -->
 {{- $js := slice $persist $collapse $minisearch $search $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
+<script>window.__BASE_URL__ = '{{ "/" | relURL }}';</script>
 <script defer src="{{ $js_min.RelPermalink }}"></script>


### PR DESCRIPTION
## Summary
- handle sites hosted under a subdirectory by passing the base URL to search.js
- look up index.json relative to the configured base URL

## Testing
- `npm test` *(fails: Missing script)*