### PR TITLE
Adjust blog page spacing

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,9 +1,9 @@
 {{- define "main" }}
-<div id="main" class="page-list pt-10">
+<div id="main" class="page-list pt-[26px]">
     <div class="container w-full max-w-[710px] mx-auto">
         {{- if eq .Section "blog" }}
         <div class="px-6 lg:px-0">
-            <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-10"></div>
+            <div class="max-w-[640px] mx-auto border-b border-b-[#E5E5E5] mb-6"></div>
         </div>
         {{- end }}
         <div>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,6 +1,6 @@
 {{- define "main" }}
 {{- if eq .Data.Plural "tags" }}
-<div id="main" class="term py-10">
+<div id="main" class="term pt-[26px] pb-10">
     <div class="container w-full max-w-[710px] mx-auto">
         <div class="px-6 md:px-0">
             <header class="max-w-[640px] mx-auto py-6 border-y border-y-[#E5E5E5] md:flex md:justify-between md:items-center mb-12">
@@ -59,10 +59,10 @@
     </div>
 </div>
 {{- else }}
-<div id="main" class="term pt-10">
+<div id="main" class="term pt-[26px]">
     <div class="container w-full max-w-[710px] mx-auto">
         <header class="max-w-[640px] mx-auto text-center">
-            <div class="pb-10 border-b border-b-[#E5E5E5]">
+            <div class="pb-6 border-b border-b-[#E5E5E5]">
                 <h3 class="text-[#0E4678] text-4xl font-heading font-normal mb-0">{{ .Title }}</h3>
             </div>
         </header>


### PR DESCRIPTION
## Summary
- tweak blog list layout spacing to match home page spacing
- adjust taxonomy templates with smaller header gaps

## Testing
- `npm run build` *(fails: hugo not found)*