### PR TITLE
Adjust tag page spacing and home anchor

### DIFF
--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -20,7 +20,7 @@
         <div class="max-w-[640px] mx-auto px-6 md:px-0">
             <hr>
         </div>
-        <div>
+        <div id="posts">
             {{- $paginator := .Paginate (where .Site.RegularPages "Type" "blog") }}
             {{- range $paginator.Pages }}
             {{ partial "post-card.html" . }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -3,12 +3,12 @@
 <div id="main" class="term pt-[26px] pb-10">
     <div class="container w-full max-w-[710px] mx-auto">
         <div class="px-6 md:px-0">
-            <header class="max-w-[640px] mx-auto py-6 border-y border-y-[#E5E5E5] md:flex md:justify-between md:items-center mb-12">
+            <header class="max-w-[640px] mx-auto py-6 border-y border-y-[#E5E5E5] md:flex md:justify-between md:items-center mb-6">
                 <div class="md:w-[70%] md:flex-none mb-6 md:mb-0">
                     <h1 class="text-black text-2xl font-heading font-normal leading-tight mb-0">Posts tagged <span class="font-semibold">#{{ .Title }}</span></h1>
                 </div>
                 <div class="inline-block">
-                    <a class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2 transition-colors duration-300 ease-[ease] hover:bg-[#0074c8] hover:text-white hover:border-[#0074c8]" href="/">
+                    <a class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2 transition-colors duration-300 ease-[ease] hover:bg-[#0074c8] hover:text-white hover:border-[#0074c8]" href="/#posts">
                         <span class="leading-none">View All Posts</span>
                         <span class="w-4 flex-none">
                             <svg class="w-full h-auto" viewBox="0 0 16 8" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- reduce spacing under tag page headers
- link "View All Posts" to posts section on the homepage
- add an anchor for posts on the homepage

## Testing
- `npm run build` *(fails: hugo not found)*