### PR TITLE
Fix tag page header spacing

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -3,7 +3,7 @@
 <div id="main" class="term pt-[26px] pb-10">
     <div class="container w-full max-w-[710px] mx-auto">
         <div class="px-6 md:px-0">
-            <header class="max-w-[640px] mx-auto py-6 border-y border-y-[#E5E5E5] md:flex md:justify-between md:items-center mb-6">
+            <header class="max-w-[640px] mx-auto py-6 border-y border-y-[#E5E5E5] md:flex md:justify-between md:items-center mb-4">
                 <div class="md:w-[70%] md:flex-none mb-6 md:mb-0">
                     <h1 class="text-black text-2xl font-heading font-normal leading-tight mb-0">Posts tagged <span class="font-semibold">#{{ .Title }}</span></h1>
                 </div>


### PR DESCRIPTION
## Summary
- reduce spacing between tag page header and posts

## Testing
- `npm run build` *(fails: `hugo` not found)*