### PR TITLE
Switch search to Pagefind

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -107,6 +107,4 @@ module:
       target: assets/js/vendor/collapse
     - source: node_modules/@alpinejs/persist
       target: assets/js/vendor/persist
-    - source: node_modules/minisearch
-      target: assets/js/vendor/minisearch
       

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -2,11 +2,11 @@
 {{- $alpine := resources.Get "js/vendor/alpinejs/dist/cdn.min.js" }}
 {{- $collapse := resources.Get "js/vendor/collapse/dist/cdn.min.js" }}
 {{- $persist := resources.Get "js/vendor/persist/dist/cdn.min.js" }}
-{{- $minisearch := resources.Get "js/vendor/minisearch/dist/umd/index.js" }}
 {{- $search := resources.Get "js/search.js" }}
 
 <!-- Combine JS -->
-{{- $js := slice $persist $collapse $minisearch $search $alpine | resources.Concat "js/main.js" }}
+{{- $js := slice $persist $collapse $search $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
 <script>window.__BASE_URL__ = '{{ "/" | relURL }}';</script>
+<script defer src="{{ "pagefind/pagefind.js" | relURL }}"></script>
 <script defer src="{{ $js_min.RelPermalink }}"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "hugo --gc --minify"
+command = "hugo --gc --minify && npx pagefind --site \"public\""
 
 [context.production.environment]
 HUGO_VERSION = "v0.134.3"
@@ -8,20 +8,20 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.split1]
-command = "hugo --gc --minify --enableGitInfo"
+command = "hugo --gc --minify --enableGitInfo && npx pagefind --site \"public\""
 
 [context.split1.environment]
 HUGO_VERSION = "v0.134.3"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL && npx pagefind --site \"public\""
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "v0.134.3"
 
 [context.branch-deploy]
-command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+command = "hugo --gc --minify -b $DEPLOY_PRIME_URL && npx pagefind --site \"public\""
 
 [context.branch-deploy.environment]
 HUGO_VERSION = "v0.134.3"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "dev": "hugo server --disableFastRender",
-        "build": "hugo --gc --minify",
+        "build": "hugo --gc --minify && npx pagefind --site \"public\"",
         "clean": "hugo --cleanDestinationDir",
         "start": "hugo server --bind 192.168.0.104 --baseURL http://192.168.0.104"
     },


### PR DESCRIPTION
## Summary
- replace Minisearch with Pagefind front-end logic
- include Pagefind bundle and update asset pipeline
- remove Minisearch mount from Hugo config
- run Pagefind after Hugo build for all Netlify contexts
- run Pagefind in npm build script

## Testing
- `npm run build` *(fails: `hugo` not found)*