### PR TITLE
Add logo above STS-I in mobile menu

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -82,9 +82,12 @@
                             {{- end }}
                         </ul>
                     </nav>
-                    <p class="absolute bottom-32 left-1/2 -translate-x-1/2 text-white opacity-50 italic font-heading lg:hidden">
-                        STS-I at USD
-                    </p>
+                      <div class="absolute bottom-32 left-1/2 -translate-x-1/2 flex flex-col items-center lg:hidden">
+                        <img src="/images/logo.png" alt="STS-I logo" class="w-8 mb-1 opacity-50 filter brightness-0 invert">
+                        <p class="text-white opacity-50 italic font-heading">
+                            STS-I at USD
+                        </p>
+                    </div>
                 </div>
                 <div class="flex items-center justify-end">
                     <div class="w-6 flex-none flex items-center justify-center ml-2">


### PR DESCRIPTION
## Summary
- add a small logo above the `STS-I at USD` text in the hamburger menu

## Testing
- `npm run build` *(fails: hugo not found)*