### PR TITLE
Fix search initialization when Pagefind script is missing

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -12,22 +12,32 @@ document.addEventListener("DOMContentLoaded", () => {
 
     let pagefindInstance = null;
     // Wait for Pagefind to be available
-    const pagefindReady = new Promise((resolve) => {
+    const pagefindReady = new Promise((resolve, reject) => {
         if (window.pagefind) {
             resolve(window.pagefind);
-        } else {
-            const check = setInterval(() => {
-                if (window.pagefind) {
-                    clearInterval(check);
-                    resolve(window.pagefind);
-                }
-            }, 50);
+            return;
         }
+        const start = Date.now();
+        const check = setInterval(() => {
+            if (window.pagefind) {
+                clearInterval(check);
+                resolve(window.pagefind);
+            } else if (Date.now() - start > 2000) {
+                clearInterval(check);
+                reject(new Error("Pagefind failed to load"));
+            }
+        }, 50);
     });
 
-    pagefindReady.then((pagefind) => {
-        pagefindInstance = pagefind;
-    });
+    pagefindReady
+        .then((pagefind) => {
+            pagefindInstance = pagefind;
+        })
+        .catch(() => {
+            resultsContainers.forEach((c) => {
+                c.innerHTML = '<p class="text-gray-600">Search is currently unavailable.</p>';
+            });
+        });
 
     const params = new URLSearchParams(window.location.search);
     const initialQuery = params.get("query");

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -8,5 +8,18 @@
 {{- $js := slice $persist $collapse $search $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
 <script>window.__BASE_URL__ = '{{ "/" | relURL }}';</script>
-<script type="module" defer src="{{ "/pagefind/pagefind.js" | absURL }}"></script>
+<script>
+  const pf = document.createElement('script');
+  pf.type = 'module';
+  pf.defer = true;
+  pf.src = '{{ "/pagefind/pagefind.js" | absURL }}';
+  pf.onerror = () => {
+    const cdn = document.createElement('script');
+    cdn.type = 'module';
+    cdn.defer = true;
+    cdn.src = 'https://cdn.pagefind.app/pagefind.js';
+    document.head.appendChild(cdn);
+  };
+  document.head.appendChild(pf);
+</script>
 <script defer src="{{ $js_min.RelPermalink }}"></script>


### PR DESCRIPTION
## Summary
- load pagefind.js with a CDN fallback
- provide error message if the Pagefind client fails to load

## Testing
- `npm run build` *(fails: `hugo: not found`)*