### PR TITLE
Switch to hugofastsearch

### DIFF
--- a/assets/js/hugofastsearch.js
+++ b/assets/js/hugofastsearch.js
@@ -1,0 +1,33 @@
+/**
+ * Simple search index loader using MiniSearch
+ */
+document.addEventListener("DOMContentLoaded", () => {
+    const state = { ready: false, miniSearch: null };
+
+    fetch(`${window.__BASE_URL__}index.json`)
+        .then((res) => res.json())
+        .then((data) => {
+            const docs = data.posts || data;
+            state.miniSearch = new MiniSearch({
+                fields: ["title", "summary", "content", "tags", "author"],
+                storeFields: ["title", "content", "url", "date"],
+            });
+            state.miniSearch.addAll(docs);
+            state.ready = true;
+            if (typeof window.hugofastsearch?._onready === "function") {
+                window.hugofastsearch._onready();
+            }
+        })
+        .catch((err) => console.error("Failed to load search index", err));
+
+    window.hugofastsearch = {
+        isReady() {
+            return state.ready;
+        },
+        search(query) {
+            if (!state.ready || !query) return [];
+            return state.miniSearch.search(query);
+        },
+        _onready: null,
+    };
+});

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -2,11 +2,12 @@
 {{- $alpine := resources.Get "js/vendor/alpinejs/dist/cdn.min.js" }}
 {{- $collapse := resources.Get "js/vendor/collapse/dist/cdn.min.js" }}
 {{- $persist := resources.Get "js/vendor/persist/dist/cdn.min.js" }}
+{{- $minisearch := resources.Get "js/minisearch.js" }}
+{{- $fastsearch := resources.Get "js/hugofastsearch.js" }}
 {{- $search := resources.Get "js/search.js" }}
 
 <!-- Combine JS -->
-{{- $js := slice $persist $collapse $search $alpine | resources.Concat "js/main.js" }}
+{{- $js := slice $persist $collapse $minisearch $fastsearch $search $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
 <script>window.__BASE_URL__ = '{{ "/" | relURL }}';</script>
-<script type="module" defer src="{{ "/pagefind/pagefind.js" | absURL }}"></script>
 <script defer src="{{ $js_min.RelPermalink }}"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "hugo --gc --minify && npx pagefind --site \"public\""
+command = "hugo --gc --minify"
 
 [context.production.environment]
 HUGO_VERSION = "v0.134.3"
@@ -8,20 +8,20 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.split1]
-command = "hugo --gc --minify --enableGitInfo && npx pagefind --site \"public\""
+command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
 HUGO_VERSION = "v0.134.3"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL && npx pagefind --site \"public\""
+command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "v0.134.3"
 
 [context.branch-deploy]
-command = "hugo --gc --minify -b $DEPLOY_PRIME_URL && npx pagefind --site \"public\""
+command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
 HUGO_VERSION = "v0.134.3"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "dev": "hugo server --disableFastRender",
-        "build": "hugo --gc --minify && npx pagefind --site \"public\"",
+        "build": "hugo --gc --minify",
         "clean": "hugo --cleanDestinationDir",
         "start": "hugo server --bind 192.168.0.104 --baseURL http://192.168.0.104"
     },
@@ -25,7 +25,6 @@
         "alpinejs": "^3.13.7",
         "autoprefixer": "^10.4.19",
         "minisearch": "^7.1.0",
-        "pagefind": "^1.3.0",
         "postcss": "^8.4.38",
         "postcss-cli": "^11.0.0",
         "postcss-import": "^16.1.0",


### PR DESCRIPTION
## Summary
- remove pagefind integration
- use HugoFastSearch based on MiniSearch
- load new search index script and library
- simplify Netlify and package build config

## Testing
- `npm run build` *(fails: `hugo` not found)*