### PR TITLE
Add placeholder examples to Share form inputs

### DIFF
--- a/layouts/partials/sections/share-form.html
+++ b/layouts/partials/sections/share-form.html
@@ -17,19 +17,19 @@
             </div>
             <div>
                 <label for="pronouns" class="block text-base font-body text-black mb-1">Preferred pronouns</label>
-                <input type="text" id="pronouns" name="Preferred pronouns" class="w-full border border-gray-300 rounded p-2" />
+                <input type="text" id="pronouns" name="Preferred pronouns" placeholder="e.g., they/them" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
             </div>
             <div>
                 <label for="affiliation" class="block text-base font-body text-black mb-1">Institutional affiliation</label>
-                <input type="text" id="affiliation" name="Institutional affiliation" class="w-full border border-gray-300 rounded p-2" />
+                <input type="text" id="affiliation" name="Institutional affiliation" placeholder="e.g., University of Example" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
             </div>
             <div>
                 <label for="email" class="block text-base font-body text-black mb-1">Email address</label>
-                <input type="email" id="email" name="Email" required class="w-full border border-gray-300 rounded p-2" />
+                <input type="email" id="email" name="Email" placeholder="name@example.edu" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
             </div>
             <div>
                 <label for="work" class="block text-base font-body text-black mb-1">Tell us about your work!</label>
-                <textarea id="work" name="Work description" rows="6" required class="w-full border border-gray-300 rounded p-2"></textarea>
+                <textarea id="work" name="Work description" rows="6" placeholder="Briefly describe your project" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75"></textarea>
             </div>
             <div>
                 <button type="submit" class="px-4 py-2 bg-primary text-white rounded">Submit</button>

--- a/layouts/partials/share-box.html
+++ b/layouts/partials/share-box.html
@@ -21,19 +21,19 @@
                 </div>
                 <div>
                     <label for="pronouns" class="block text-base font-body text-black mb-1">Preferred pronouns</label>
-                    <input type="text" id="pronouns" name="Preferred pronouns" class="w-full border border-gray-300 rounded p-2" />
+                    <input type="text" id="pronouns" name="Preferred pronouns" placeholder="e.g., they/them" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
                 </div>
                 <div>
                     <label for="affiliation" class="block text-base font-body text-black mb-1">Institutional affiliation</label>
-                    <input type="text" id="affiliation" name="Institutional affiliation" class="w-full border border-gray-300 rounded p-2" />
+                    <input type="text" id="affiliation" name="Institutional affiliation" placeholder="e.g., University of Example" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
                 </div>
                 <div>
                     <label for="email" class="block text-base font-body text-black mb-1">Email address</label>
-                    <input type="email" id="email" name="Email" required class="w-full border border-gray-300 rounded p-2" />
+                    <input type="email" id="email" name="Email" placeholder="name@example.edu" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
                 </div>
                 <div>
                     <label for="work" class="block text-base font-body text-black mb-1">Tell us about your work!</label>
-                    <textarea id="work" name="Work description" rows="6" required class="w-full border border-gray-300 rounded p-2"></textarea>
+                    <textarea id="work" name="Work description" rows="6" placeholder="Briefly describe your project" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75"></textarea>
                 </div>
                 <div>
                     <button type="submit" class="px-4 py-2 bg-primary text-white rounded">Submit</button>


### PR DESCRIPTION
## Summary
- add example placeholders to the share form section
- add the same placeholders to the share box modal

## Testing
- `npm run build` *(fails: hugo not found)*