### PR TITLE
Disable body scroll when share form open

### DIFF
--- a/layouts/partials/share-box.html
+++ b/layouts/partials/share-box.html
@@ -1,4 +1,6 @@
-<div x-show="isShare" x-transition.opacity x-cloak class="fixed inset-0 bg-black/70 z-40 p-6 pt-32 overflow-auto">
+<div x-show="isShare" x-transition.opacity x-cloak
+    x-effect="document.body.classList.toggle('overflow-hidden', isShare); document.documentElement.classList.toggle('overflow-hidden', isShare)"
+    class="fixed inset-0 bg-black/70 z-40 p-6 pt-32 overflow-auto">
     <div class="bg-white w-full max-w-[640px] mx-auto h-auto relative rounded-lg shadow-lg">
         <div class="pt-6 px-8 pb-10">
             <div class="flex justify-between items-center mb-5">


### PR DESCRIPTION
## Summary
- prevent scrolling the page while the "Share Your Work" form modal is visible

## Testing
- `npm run build` *(fails: `hugo` not found)*