### PR TITLE
Add pronoun select to Share Your Work form

### DIFF
--- a/assets/js/pronouns.js
+++ b/assets/js/pronouns.js
@@ -1,0 +1,15 @@
+// Syncs pronoun select with text input on share forms
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('form[name="share-work"]').forEach(form => {
+        const textInput = form.querySelector('input[name="Preferred pronouns"]');
+        const selectInput = form.querySelector('select[data-pronouns-select]');
+        if (!textInput || !selectInput) return;
+
+        selectInput.addEventListener('change', () => {
+            if (selectInput.value) {
+                textInput.value = selectInput.value;
+            }
+        });
+    });
+});

--- a/layouts/partials/head/site-js.html
+++ b/layouts/partials/head/site-js.html
@@ -6,9 +6,10 @@
 {{- $fastsearch := resources.Get "js/hugofastsearch.js" }}
 {{- $search := resources.Get "js/search.js" }}
 {{- $emailvalidate := resources.Get "js/email-validation.js" }}
+{{- $pronouns := resources.Get "js/pronouns.js" }}
 
 <!-- Combine JS -->
-{{- $js := slice $persist $collapse $minisearch $fastsearch $search $emailvalidate $alpine | resources.Concat "js/main.js" }}
+{{- $js := slice $persist $collapse $minisearch $fastsearch $search $emailvalidate $pronouns $alpine | resources.Concat "js/main.js" }}
 {{- $js_min := $js | resources.Minify }}
 <script>window.__BASE_URL__ = '{{ "/" | relURL }}';</script>
 <script defer src="{{ $js_min.RelPermalink }}"></script>

--- a/layouts/partials/sections/share-form.html
+++ b/layouts/partials/sections/share-form.html
@@ -17,7 +17,16 @@
             </div>
             <div>
                 <label for="pronouns" class="block text-base font-body text-black mb-1">Preferred pronouns</label>
-                <input type="text" id="pronouns" name="Preferred pronouns" placeholder="e.g., they/them" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
+                <div class="flex flex-col sm:flex-row sm:space-x-2">
+                    <input type="text" id="pronouns" name="Preferred pronouns" placeholder="e.g., they/them" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75 mb-2 sm:mb-0" />
+                    <select data-pronouns-select class="w-full sm:w-40 border border-gray-300 rounded p-2 bg-white text-black">
+                        <option value="">Select</option>
+                        <option value="they/them">they/them</option>
+                        <option value="she/her">she/her</option>
+                        <option value="he/him">he/him</option>
+                        <option value="Prefer not to say">Prefer not to say</option>
+                    </select>
+                </div>
             </div>
             <div>
                 <label for="affiliation" class="block text-base font-body text-black mb-1">Institutional affiliation</label>

--- a/layouts/partials/share-box.html
+++ b/layouts/partials/share-box.html
@@ -23,7 +23,16 @@
                 </div>
                 <div>
                     <label for="pronouns" class="block text-base font-body text-black mb-1">Preferred pronouns</label>
-                    <input type="text" id="pronouns" name="Preferred pronouns" placeholder="e.g., they/them" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75" />
+                    <div class="flex flex-col sm:flex-row sm:space-x-2">
+                        <input type="text" id="pronouns" name="Preferred pronouns" placeholder="e.g., they/them" class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75 mb-2 sm:mb-0" />
+                        <select data-pronouns-select class="w-full sm:w-40 border border-gray-300 rounded p-2 bg-white text-black">
+                            <option value="">Select</option>
+                            <option value="they/them">they/them</option>
+                            <option value="she/her">she/her</option>
+                            <option value="he/him">he/him</option>
+                            <option value="Prefer not to say">Prefer not to say</option>
+                        </select>
+                    </div>
                 </div>
                 <div>
                     <label for="affiliation" class="block text-base font-body text-black mb-1">Institutional affiliation</label>


### PR DESCRIPTION
## Summary
- implement pronoun select and free text input for the Share Your Work forms
- sync dropdown with text input via new JavaScript helper
- bundle new JavaScript in site scripts

## Testing
- `npm run build` *(fails: hugo not found)*