### PR TITLE
Add Netlify reCAPTCHA to form

### DIFF
--- a/layouts/partials/sections/share-form.html
+++ b/layouts/partials/sections/share-form.html
@@ -31,6 +31,7 @@
                 <label for="work" class="block text-base font-body text-black mb-1">Tell us about your work!</label>
                 <textarea id="work" name="Work description" rows="6" placeholder="Briefly describe your project" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75"></textarea>
             </div>
+            <div data-netlify-recaptcha="true"></div>
             <div>
                 <button type="submit" class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2 transition-colors duration-300 ease-[ease] hover:bg-[#0074c8] hover:text-white hover:border-[#0074c8]">
                     <span class="leading-none">Submit</span>
@@ -42,6 +43,7 @@
                 </button>
             </div>
         </form>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     </div>
 </section>
 {{- end }}

--- a/layouts/partials/share-box.html
+++ b/layouts/partials/share-box.html
@@ -37,6 +37,7 @@
                     <label for="work" class="block text-base font-body text-black mb-1">Tell us about your work!</label>
                     <textarea id="work" name="Work description" rows="6" placeholder="Briefly describe your project" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75"></textarea>
                 </div>
+                <div data-netlify-recaptcha="true"></div>
                 <div>
                     <button type="submit" class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2 transition-colors duration-300 ease-[ease] hover:bg-[#0074c8] hover:text-white hover:border-[#0074c8]">
                         <span class="leading-none">Submit</span>
@@ -48,6 +49,7 @@
                     </button>
                 </div>
             </form>
+            <script src="https://www.google.com/recaptcha/api.js" async defer></script>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add Netlify reCAPTCHA v2 to the Share Your Work page form
- include the same reCAPTCHA protection in the popup form

## Testing
- `npm run build` *(fails: hugo not found)*