### PR TITLE
Remove standalone share form page

### DIFF
--- a/content/pages/share-your-work.md
+++ b/content/pages/share-your-work.md
@@ -1,9 +1,0 @@
----
-title: Share Your Work
-description: Share your scholarship or projects
-slug: share-your-work
-layout: page-builder
-sections:
-  - template: share-form
-    enable: true
----

--- a/data/page_header.yaml
+++ b/data/page_header.yaml
@@ -1,3 +1,3 @@
 title: Nothing on earth exists in a permanent vacuum, least of all science and technology.
 button_text: Share Your Work
-button_link: "/share-your-work/"
+button_link: "#"


### PR DESCRIPTION
## Summary
- remove `share-your-work` page so the form only appears in the homepage pop-up
- update page header config to use `#` for the share link

## Testing
- `npm run build` *(fails: hugo not found)*