### PR TITLE
Fix captcha sizing on mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -93,3 +93,16 @@ body {
 .highlight {
     @apply bg-yellow-200;
 }
+
+/* Adjust captcha size on smaller screens */
+.recaptcha-wrapper>div {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+@media (max-width: 767px) {
+    .recaptcha-wrapper {
+        transform: scale(0.9);
+        transform-origin: 0 0;
+    }
+}

--- a/layouts/partials/sections/share-form.html
+++ b/layouts/partials/sections/share-form.html
@@ -31,7 +31,7 @@
                 <label for="work" class="block text-base font-body text-black mb-1">Tell us about your work!<span class="ml-1 text-red-600" aria-hidden="true">*</span></label>
                 <textarea id="work" name="Work description" rows="6" placeholder="Briefly describe your project" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75 min-h-[150px]"></textarea>
             </div>
-            <div data-netlify-recaptcha="true"></div>
+            <div data-netlify-recaptcha="true" class="recaptcha-wrapper"></div>
             <div>
                 <button type="submit" class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2 transition-colors duration-300 ease-[ease] hover:bg-[#0074c8] hover:text-white hover:border-[#0074c8]">
                     <span class="leading-none">Submit</span>

--- a/layouts/partials/share-box.html
+++ b/layouts/partials/share-box.html
@@ -37,7 +37,7 @@
                     <label for="work" class="block text-base font-body text-black mb-1">Tell us about your work!<span class="ml-1 text-red-600" aria-hidden="true">*</span></label>
                     <textarea id="work" name="Work description" rows="6" placeholder="Briefly describe your project" required class="w-full border border-gray-300 rounded p-2 placeholder:text-gray-400 placeholder:opacity-75 min-h-[150px]"></textarea>
                 </div>
-                <div data-netlify-recaptcha="true"></div>
+                <div data-netlify-recaptcha="true" class="recaptcha-wrapper"></div>
                 <div>
                     <button type="submit" class="flex items-center space-x-4 border-2 border-primary rounded-[4px] text-primary text-sm font-body pt-3 pb-[10px] px-2 transition-colors duration-300 ease-[ease] hover:bg-[#0074c8] hover:text-white hover:border-[#0074c8]">
                         <span class="leading-none">Submit</span>


### PR DESCRIPTION
## Summary
- target recaptcha containers for better mobile sizing
- add `recaptcha-wrapper` class in share form partials

## Testing
- `npm run build` *(fails: `hugo: not found`)*