### PR TITLE
Add SRI parameter for reCAPTCHA

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -2,3 +2,4 @@ description: leoambrogelly
 # Your favicon must be located in the assets/images folder
 favicon: images/favicon.png
 author: leoambrogelly
+recaptcha_sri: ""

--- a/layouts/partials/sections/share-form.html
+++ b/layouts/partials/sections/share-form.html
@@ -43,7 +43,8 @@
                 </button>
             </div>
         </form>
-        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+        {{- $sri := site.Params.recaptcha_sri }}
+        <script src="https://www.google.com/recaptcha/api.js" async defer{{ with $sri }} integrity="{{ . }}" crossorigin="anonymous"{{ end }}></script>
     </div>
 </section>
 {{- end }}

--- a/layouts/partials/share-box.html
+++ b/layouts/partials/share-box.html
@@ -49,7 +49,8 @@
                     </button>
                 </div>
             </form>
-            <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+            {{- $sri := site.Params.recaptcha_sri }}
+            <script src="https://www.google.com/recaptcha/api.js" async defer{{ with $sri }} integrity="{{ . }}" crossorigin="anonymous"{{ end }}></script>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- load optional recaptcha SRI from config
- add attributes for subresource integrity on reCAPTCHA scripts

## Testing
- `npm run build` *(fails: hugo not found)*