### PR TITLE
Set canonical HTTPS baseURL

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -1,6 +1,6 @@
 ---
 title: STS-I at USD
-baseURL: /
+baseURL: https://stsiatusd.org/
 languageCode: en
 defaultContentLanguage: en
 services:


### PR DESCRIPTION
## Summary
- set `baseURL` to `https://stsiatusd.org/` for canonical HTTPS links

## Testing
- `npm run build` *(fails: `hugo` not found)*