### PR TITLE
Improve share-work form validation messages

### DIFF
--- a/assets/css/partials/form.css
+++ b/assets/css/partials/form.css
@@ -1,0 +1,7 @@
+.form-error {
+    @apply text-red-600 text-sm mt-1;
+}
+
+.invalid-input {
+    @apply border-red-600;
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -5,6 +5,7 @@
 @import "partials/fonts.css";
 @import "partials/highlighter.css";
 @import "partials/button.css";
+@import "partials/form.css";
 @import "site.css";
 
 [x-cloak] {

--- a/assets/js/email-validation.js
+++ b/assets/js/email-validation.js
@@ -1,10 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('form[name="share-work"]').forEach((form) => {
+        form.setAttribute('novalidate', '');
         const requiredFields = form.querySelectorAll('input[required], textarea[required]');
 
         requiredFields.forEach((field) => {
             const errorEl = document.createElement('p');
-            errorEl.className = 'text-red-600 text-sm mt-1 hidden';
+            errorEl.className = 'form-error hidden';
             field.insertAdjacentElement('afterend', errorEl);
 
             const validateField = () => {
@@ -25,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 field.setCustomValidity(message);
                 errorEl.textContent = message;
                 errorEl.classList.toggle('hidden', !message);
-                field.classList.toggle('border-red-600', !!message);
+                field.classList.toggle('invalid-input', !!message);
             };
 
             field.addEventListener('input', validateField);


### PR DESCRIPTION
## Summary
- refine validation script with consistent `form-error` styling
- add utility classes for form errors and invalid inputs

## Testing
- `npm run build` *(fails: hugo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452dea8c708320b422071eb70b65bb