### PR TITLE
Darken search icon on hover

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -93,11 +93,11 @@
                 </div>
                 <div class="flex items-center justify-end">
                     <div class="w-6 flex-none flex items-center justify-center ml-2">
-                        <button @click="isSearch = true">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <button @click="isSearch = true" class="transition-colors duration-300 text-[#0074C8] hover:text-[#003B70]">
+                            <svg class="stroke-current" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path
                                     d="M21 21L16.65 16.65M19 11C19 15.4183 15.4183 19 11 19C6.58172 19 3 15.4183 3 11C3 6.58172 6.58172 3 11 3C15.4183 3 19 6.58172 19 11Z"
-                                    stroke="#0074C8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+                                    class="stroke-current" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
                             </svg>
                         </button>
                     </div>


### PR DESCRIPTION
## Summary
- darken search icon in header on hover

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68452e4344ec83209c8fc67fbf791ad4