### PR TITLE
Add hover effects on about page cards

### DIFF
--- a/layouts/partials/sections/about-content.html
+++ b/layouts/partials/sections/about-content.html
@@ -13,7 +13,7 @@
         {{- if .card }}
         <div class="md:flex md:space-x-10 pb-10 border-b border-b-[#E5E5E5]">
             {{- range .card }}
-            <div class="md:w-1/2 border border-[#E5E5E5] rounded-[4px] px-5 pt-3 pb-6 mb-10 lg:mb-0">
+            <div class="md:w-1/2 border border-[#E5E5E5] rounded-[4px] px-5 pt-3 pb-6 mb-10 lg:mb-0 transition-all duration-300 ease-in-out hover:-translate-y-1 hover:shadow-lg">
                 {{- with .title }}
                 <header>
                     <h3 class="text-[#104879] text-base font-body font-normal leading-snug mb-7">{{ . | safeHTML }}</h3>


### PR DESCRIPTION
## Summary
- make the about page cards float and cast a shadow on hover

## Testing
- `npm run build` *(fails: hugo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845317e5e10832095f251c5ed091517