### PR TITLE
Fix FAQ close icon thickness

### DIFF
--- a/layouts/partials/sections/about-aq.html
+++ b/layouts/partials/sections/about-aq.html
@@ -27,8 +27,8 @@
                             <svg
                                 :class="openIndex === {{ $index }} ? 'rotate-0 opacity-100' : '-rotate-45 opacity-0'"
                                 class="absolute inset-0 transition-all duration-300 transform"
-                                width="18" height="22" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path fill-rule="evenodd" clip-rule="evenodd" d="M9.20711 10.2071L16 17L16.7071 16.2928L9.91421 9.49995L16.7071 2.70706L16 1.99995L9.20711 8.79285L1.70711 1.29285L1 1.99995L8.5 9.49995L1 17L1.70711 17.7071L9.20711 10.2071Z" fill="black"/>
+                                width="18" height="22" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M1 1L17 17M17 1L1 17" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                             </svg>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- thicken the close icon so it matches the down arrow

## Testing
- `npm run build` *(fails: `hugo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68840d67fe3083209ddd17d1369e2fba